### PR TITLE
Fix package.json to point to index.js, not missing API.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@textile/textile",
   "version": "0.0.0",
   "description": "JS lib for interacting with Textile APIs.",
-  "main": "dist/src/API.js",
-  "types": "dist/src/API.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test:node": "mocha --exit --require ts-node/register --require source-map-support/register --recursive src/**.spec.ts",


### PR DESCRIPTION
## Description

Fixes all imports of '@textile/textile' failing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested as it's convoluted to test NPM packages without publishing them... guidance welcome.

