### PR TITLE
fix(lint): rm console log; add specific buffer test

### DIFF
--- a/packages/buckets/src/api/index.ts
+++ b/packages/buckets/src/api/index.ts
@@ -416,7 +416,6 @@ export async function bucketsLinks(
   const req = new LinksRequest()
   req.setKey(key)
   req.setPath(path)
-  console.log(path)
   const res: LinksResponse = await api.unary(APIService.Links, req, ctx)
   return res.toObject()
 }

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -235,6 +235,21 @@ describe('Buckets...', function () {
       expect(list.item?.items).to.have.length(2) // Includes .textileseed
     })
 
+    it('should push data from Buffer', async function () {
+      const content = 'some content'
+      const file = { path: '/index.html', content: Buffer.from(content) }
+
+      const rootKey = buck.root?.key || ''
+
+      const { root } = await client.pushPath(rootKey, 'index.html', file)
+      expect(root).to.not.be.undefined
+
+      // Root dir
+      const rep = await client.listPath(rootKey, '')
+      expect(rep.item?.isDir).to.be.true
+      expect(rep.item?.items).to.have.length(3)
+    })
+
     it('should list bucket links', async function () {
       const rootKey = buck.root?.key || ''
 


### PR DESCRIPTION
i was just doing this chore https://github.com/textileio/js-examples/pull/37 and hit something really strange in the React Native example, where it errors out on the file chunking method. it says `... not an interator` and crashes. so chucked this test in here to try and see if it existed elsewhere. but haven't found it yet. will return after next release.