### PR TITLE
Adds abort controller support + root fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,17 +5,8 @@
     "commonjs": true,
     "node": true
   },
-  "extends": [
-    "plugin:prettier/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint",
-    "plugin:import/typescript"
-  ],
-  "plugins": [
-    "@typescript-eslint",
-    "prettier",
-    "import"
-  ],
+  "extends": ["plugin:prettier/recommended", "plugin:@typescript-eslint/recommended", "prettier/@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "prettier"],
   "globals": {
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"
@@ -30,17 +21,8 @@
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/explicit-member-accessibility": 0,
-    "@typescript-eslint/no-unused-vars": [0, {"argsIgnorePattern": "^_"}],
+    "@typescript-eslint/no-unused-vars": [0, { "argsIgnorePattern": "^_" }],
     "no-undefined": 0,
-    "default-case": 0,
-    "import/no-absolute-path": 2,
-    "import/no-cycle": 1,
-    "import/export": 2,
-    "import/no-named-as-default": 2,
-    "import/no-named-as-default-member": 2,
-    "import/first": 2,
-    "import/order": 2,
-    "import/newline-after-import": 2,
-    "import/no-default-export": 2
+    "default-case": 0
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3044,17 +3044,6 @@
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
-    "array-includes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
-        "is-string": "^1.0.5"
-      }
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -3075,16 +3064,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
-    },
-    "array.prototype.flat": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -4555,12 +4534,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
-    },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -6321,60 +6294,6 @@
         }
       }
     },
-    "eslint-import-resolver-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.13.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.9",
-        "pkg-dir": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-es": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
@@ -6395,54 +6314,6 @@
         "lodash.kebabcase": "4.1.1",
         "lodash.snakecase": "4.1.1",
         "lodash.upperfirst": "4.3.1"
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flat": "^1.2.3",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.9",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.3",
-        "eslint-module-utils": "^2.6.0",
-        "has": "^1.0.3",
-        "minimatch": "^3.0.4",
-        "object.values": "^1.1.1",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.17.0",
-        "tsconfig-paths": "^3.9.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-node": {
@@ -9233,12 +9104,6 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
-    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -9775,18 +9640,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
-    },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
-      }
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -12095,18 +11948,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "object.values": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -12785,15 +12626,6 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "^2.0.0"
-      }
-    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -12850,15 +12682,6 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.1.0"
       }
     },
     "pluralize": {
@@ -13677,27 +13500,6 @@
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
         "util-promisify": "^2.1.0"
-      }
-    },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint": "^6.7.1",
     "eslint-config-prettier": "^6.7.0",
     "eslint-config-strict": "^14.0.1",
-    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "lerna": "^3.19.0",

--- a/packages/buckets/package-lock.json
+++ b/packages/buckets/package-lock.json
@@ -146,6 +146,14 @@
 				"@types/node": "*"
 			}
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
 		"axios": {
 			"version": "0.20.0",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
@@ -252,6 +260,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
 			"integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
 		},
 		"fast-sha256": {
 			"version": "1.3.0",

--- a/packages/buckets/package.json
+++ b/packages/buckets/package.json
@@ -41,6 +41,7 @@
     "@textile/security": "^0.3.0",
     "@textile/threads-id": "^0.1.15",
     "@types/next-tick": "^1.0.0",
+    "abort-controller": "^3.0.0",
     "cids": "^0.8.0",
     "event-iterator": "^2.0.0",
     "it-block": "^2.0.0",

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -1,7 +1,7 @@
 import { Context } from '@textile/context'
 import { PrivateKey } from '@textile/crypto'
 import { SignupResponse } from '@textile/hub-grpc/hub_pb'
-import { AbortController } from 'abort-controller'
+import AbortController from 'abort-controller'
 import { isBrowser, isNode } from 'browser-or-node'
 import { expect } from 'chai'
 import fs from 'fs'

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -342,7 +342,6 @@ describe('Buckets...', function () {
 
   describe('aborting', function () {
     it('should allow an abort controler to signal a cancel event on a push', async function () {
-      if (isBrowser) return this.skip() // We're going to use a large file, so skip this in browser
       const { root } = await client.getOrCreate('aborted')
 
       // Create an infinate stream of bytes

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -38,6 +38,7 @@ import {
   PathAccessRole,
   PathItemObject,
   PathObject,
+  PushOptions,
   PushPathResult,
   RootObject,
 } from './api'
@@ -481,7 +482,7 @@ export class Buckets extends GrpcAuthentication {
    * @param key Unique (IPNS compatible) identifier key for a bucket.
    * @param path A file/object (sub)-path within a bucket.
    * @param input The input file/stream/object.
-   * @param opts Options to control response stream. Currently only supports a progress function.
+   * @param opts Options to control response stream.
    * @remarks
    * This will return the resolved path and the bucket's new root path.
    * @example
@@ -520,12 +521,7 @@ export class Buckets extends GrpcAuthentication {
    * }
    * ```
    */
-  async pushPath(
-    key: string,
-    path: string,
-    input: any,
-    opts?: { progress?: (num?: number) => void },
-  ): Promise<PushPathResult> {
+  async pushPath(key: string, path: string, input: any, opts?: PushOptions): Promise<PushPathResult> {
     return bucketsPushPath(this, key, path, input, opts)
   }
 

--- a/packages/buckets/src/spec.util.ts
+++ b/packages/buckets/src/spec.util.ts
@@ -1,11 +1,11 @@
+import { ContextInterface } from '@textile/context'
+import { WebsocketTransport } from '@textile/grpc-transport'
+import * as pb from '@textile/hub-grpc/hub_pb'
+import { APIServiceClient, ServiceError } from '@textile/hub-grpc/hub_pb_service'
 import axios from 'axios'
 import delay from 'delay'
 import { HMAC } from 'fast-sha256'
 import multibase from 'multibase'
-import * as pb from '@textile/hub-grpc/hub_pb'
-import { APIServiceClient, ServiceError } from '@textile/hub-grpc/hub_pb_service'
-import { ContextInterface } from '@textile/context'
-import { WebsocketTransport } from '@textile/grpc-transport'
 
 export const createUsername = (size = 12) => {
   return Array(size)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -108,6 +108,7 @@
       "hub.buckets.listipfspath",
       "hub.buckets.open",
       "hub.buckets.pushpath",
+      "hub.buckets.pushoptions",
       "hub.buckets.pushpathaccessroles",
       "hub.buckets.pullpath",
       "hub.buckets.pullpathaccessroles",
@@ -117,8 +118,8 @@
       "hub.buckets.setpath"
     ],
     "Experimental": [
-      "hub.archive", 
-      "hub.archiveinfo", 
+      "hub.archive",
+      "hub.archiveinfo",
       "hub.buckets.archiveinfo",
       "hub.archivedealinfo",
       "hub.buckets.archivestatus",


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This PR adds two new "features", both of which are optional. This should avoid and major breaking changes, but should provide improvements in behavior when pushing buckets in most cases. Note that eventually, some of these options should/will be made non-optional/the default.

This adds support for an AbortSignal from an AbortController to be used to ensure that a given pushPath connection with a remote buckd service is closed. It essentially adds support for canceling an ongoing Bucket pushPath call. This should be used by callers at all times when there is the possibility that a pushPath will timeout, error, or otherwise not complete safely. So in practice, an AbortController should be used all the time. The nice thing here is that you can use the same signal for multiple calls, so that in the case of _any_ failure, all ongoing transactions can be aborted.

This also adds better default behavior for specifying the current "root" of a bucket during a pushPath. This ensures that only fast-forward only pushes are possible, and should now error properly if a caller tries to pushPath to a "stale" bucket state. The default here is to simply fire off another listPath call to get the latest bucket root. If a caller would like to avoid an additional API call, they should query the root themselves, maintain a reference to this, and then update it accordingly. Some additional examples could be added to help illustrate this. For instance, in the event of multiple pushes in a row, the "root" can be passed from one push to the next.

This fixes a number of issues we've been observing with buckets lately, though the full extend of the fix may reach beyond this. Additionally, the AbortController fix only helps if it is used. We'll have to create some good docs to support/and promote its use.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

All local tests should continue to pass (should be backward compatible), and new tests have been created to reflect the new features/options. Note that some regression tests should be created in the future, once these options become the default.