### PR TITLE
Include text-encoder/decoder polyfill

### DIFF
--- a/packages/crypto/package-lock.json
+++ b/packages/crypto/package-lock.json
@@ -110,6 +110,11 @@
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
 			"dev": true
 		},
+		"fastestsmallesttextencoderdecoder": {
+			"version": "1.0.22",
+			"resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+			"integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
+		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@types/ed2curve": "^0.2.2",
     "ed2curve": "^0.3.0",
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "multibase": "^3.1.0",
     "tweetnacl": "^1.0.3"
   }

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,11 +1,12 @@
+import 'fastestsmallesttextencoderdecoder'
+export { Identity, Private, Public } from './identity'
 export { PrivateKey, PublicKey } from './keypair'
-export { Private, Identity, Public } from './identity'
 export {
-  encrypt,
   decrypt,
-  publicKeyToString,
-  publicKeyBytesToString,
-  publicKeyBytesFromString,
-  privateKeyFromString,
+  encrypt,
   extractPublicKeyBytes,
+  privateKeyFromString,
+  publicKeyBytesFromString,
+  publicKeyBytesToString,
+  publicKeyToString,
 } from './utils'

--- a/packages/crypto/src/keypair.spec.ts
+++ b/packages/crypto/src/keypair.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { keys } from 'libp2p-crypto'
 import type { Private, Public } from './identity'
 import { PrivateKey, PublicKey } from './keypair'
-import { encrypt, decrypt } from './utils'
+import { decrypt, encrypt } from './utils'
 
 describe('Keypair', () => {
   // Type checking/external lib support

--- a/packages/crypto/src/keypair.ts
+++ b/packages/crypto/src/keypair.ts
@@ -1,15 +1,20 @@
-import nacl from 'tweetnacl'
 import multibase from 'multibase'
+import nacl from 'tweetnacl'
 import { Private, Public } from './identity'
-import { encodePublicKey, encodePrivateKey, KeyType } from './proto.keys'
-// eslint-disable-next-line import/no-cycle
-import { publicKeyToString, privateKeyFromString, publicKeyBytesFromString, encrypt, decrypt } from './utils'
+import { encodePrivateKey, encodePublicKey, KeyType } from './proto.keys'
+import {
+  decrypt,
+  encrypt,
+  privateKeyFromString,
+  publicKeyBytesFromString,
+  publicKeyToString,
+} from './utils'
 
 /**
  * Encode the given PrivateKey to its base-32 encoded multibase representation.
  * @param key The input PrivateKey.
  */
-export function privateKeyToString(key: PrivateKey) {
+export function privateKeyToString(key: PrivateKey): string {
   const encoded = multibase.encode('base32', key.bytes as Buffer)
   return new TextDecoder().decode(encoded)
 }
@@ -88,7 +93,7 @@ export class PublicKey implements Public {
    * @param data The data to use for verification.
    * @param sig The signature to verify.
    */
-  async verify(data: Uint8Array, signature: Uint8Array) {
+  async verify(data: Uint8Array, signature: Uint8Array): Promise<boolean> {
     return nacl.sign.detached.verify(data, signature, this.pubKey)
   }
 
@@ -103,7 +108,7 @@ export class PublicKey implements Public {
   /**
    * Create a PublicKey from the result of calling `toString()`.
    */
-  static fromString(str: string) {
+  static fromString(str: string): PublicKey {
     const bytes = publicKeyBytesFromString(str)
     return new PublicKey(bytes, 'ed25519')
   }

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -1,6 +1,6 @@
-import nacl from 'tweetnacl'
 import { convertPublicKey, convertSecretKey } from 'ed2curve'
 import multibase from 'multibase'
+import nacl from 'tweetnacl'
 import type { Public } from './identity'
 import { decodePrivateKey, decodePublicKey } from './proto.keys'
 
@@ -17,7 +17,11 @@ const publicKeyBytes = 32 // Length of nacl ephemeral public key
  * @see {@link https://github.com/dchest/ed2curve-js} for conversion details.
  * @param ciphertext Data to decrypt.
  */
-export async function decrypt(ciphertext: Uint8Array, privKey: Uint8Array, type = 'ed25519'): Promise<Uint8Array> {
+export async function decrypt(
+  ciphertext: Uint8Array,
+  privKey: Uint8Array,
+  type = 'ed25519',
+): Promise<Uint8Array> {
   if (type !== 'ed25519') {
     throw Error(`'${type}' type keys are not currently supported`)
   }
@@ -44,7 +48,11 @@ export async function decrypt(ciphertext: Uint8Array, privKey: Uint8Array, type 
  * @see {@link https://github.com/dchest/ed2curve-js} for conversion details.
  * @param data Data to encrypt.
  */
-export async function encrypt(data: Uint8Array, pubKey: Uint8Array, type = 'ed25519'): Promise<Uint8Array> {
+export async function encrypt(
+  data: Uint8Array,
+  pubKey: Uint8Array,
+  type = 'ed25519',
+): Promise<Uint8Array> {
   if (type !== 'ed25519') {
     throw Error(`'${type}' type keys are not currently supported`)
   }
@@ -58,7 +66,9 @@ export async function encrypt(data: Uint8Array, pubKey: Uint8Array, type = 'ed25
   // encrypt with nacl
   const nonce = nacl.randomBytes(24)
   const ciphertext = nacl.box(data, nonce, pk, ephemeral.secretKey)
-  const merged = new Uint8Array(nonceBytes + publicKeyBytes + ciphertext.byteLength)
+  const merged = new Uint8Array(
+    nonceBytes + publicKeyBytes + ciphertext.byteLength,
+  )
   // prepend nonce
   merged.set(new Uint8Array(nonce), 0)
   // then ephemeral public key
@@ -90,7 +100,7 @@ export function publicKeyToString(key: Public): string {
  * Decode the given base-32 encoded multibase string into a {@link Public} key.
  * @param str The base-32 encoded multibase string.
  */
-export function publicKeyBytesFromString(str: string) {
+export function publicKeyBytesFromString(str: string): Uint8Array {
   const decoded = multibase.decode(str)
   const obj = decodePublicKey(decoded)
   const bytes = obj.Data
@@ -101,7 +111,7 @@ export function publicKeyBytesFromString(str: string) {
  * Decode the given base-32 encoded multibase string into a {@link Private} key.
  * @param str The base-32 encoded multibase string.
  */
-export function privateKeyFromString(str: string) {
+export function privateKeyFromString(str: string): Uint8Array {
   const decoded = multibase.decode(str)
   const obj = decodePrivateKey(decoded)
   const bytes = obj.Data


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

Some downstream users have complained that they don't have the TextEncoder/Decoder APIs in NodeJS. This polyfill should automatically include these in env where the API is not already available.

Fixes #636 
Fixes #741

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not tests have been updated, the existing tests should continue to pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
