### PR TITLE
Support more schema formats (doesn't affect remote)

### DIFF
--- a/packages/threaddb/package-lock.json
+++ b/packages/threaddb/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@textile/threaddb",
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@improbable-eng/grpc-web": "^0.14.0",
@@ -14,6 +14,7 @@
 				"@types/json-schema": "^7.0.7",
 				"@types/to-json-schema": "^0.2.0",
 				"ajv": "^8.6.2",
+				"ajv-formats": "^2.1.1",
 				"buffer": "^6.0.3",
 				"dexie": "3.0.2",
 				"dexie-mongoify": "^1.3.0",
@@ -79,6 +80,22 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -983,6 +1000,14 @@
 				"json-schema-traverse": "^1.0.0",
 				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"requires": {
+				"ajv": "^8.0.0"
 			}
 		},
 		"ansi-regex": {

--- a/packages/threaddb/package.json
+++ b/packages/threaddb/package.json
@@ -31,6 +31,7 @@
     "@types/json-schema": "^7.0.7",
     "@types/to-json-schema": "^0.2.0",
     "ajv": "^8.6.2",
+    "ajv-formats": "^2.1.1",
     "buffer": "^6.0.3",
     "dexie": "3.0.2",
     "dexie-mongoify": "^1.3.0",

--- a/packages/threaddb/src/middleware/schemas/index.ts
+++ b/packages/threaddb/src/middleware/schemas/index.ts
@@ -1,4 +1,5 @@
 import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
 import Dexie, {
   DBCore,
   DBCoreMutateRequest,
@@ -11,6 +12,9 @@ import {
   initOverrideCreateTransaction,
   initOverrideParseStoreSpec,
 } from '../overrides'
+
+const ajv = new Ajv({ useDefaults: true })
+addFormats(ajv)
 
 export const SchemasTableName = '_schemas'
 
@@ -48,7 +52,7 @@ export function createSchemaMiddleware(core: DBCore): DBCore {
             .table(SchemasTableName)
             .get({ key: tableName, trans: req.trans })
           const schema: JSONSchema = pair?.schema ?? defaultSchema
-          const validator = new Ajv({ useDefaults: true }).compile(schema)
+          const validator = ajv.compile(schema)
           // We only need to worry about validation when mutating data
           try {
             switch (req.type) {


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

Supports additional schema types in the local threaddb repo. This doesn't affect the remote in any way, so incompatibilities there will cause issues for folks.

