### PR TITLE
Use context.toMetadata to trigger token refresh

### DIFF
--- a/packages/grpc-connection/src/index.ts
+++ b/packages/grpc-connection/src/index.ts
@@ -26,13 +26,14 @@ export class GrpcConnection {
     grpc.setDefaultTransport(transport)
   }
 
-  public unary<
+  public async unary<
     R extends grpc.ProtobufMessage,
     T extends grpc.ProtobufMessage,
     M extends grpc.UnaryMethodDefinition<R, T>
   >(methodDescriptor: M, req: R, ctx?: ContextInterface): Promise<T> {
+    const context = new Context().withContext(this.context).withContext(ctx)
+    const metadata = await context.toMetadata()
     return new Promise<T>((resolve, reject) => {
-      const metadata = ctx ? { ...ctx.toJSON() } : { ...this.context.toJSON() }
       grpc.unary(methodDescriptor, {
         request: req,
         host: this.serviceHost,


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

Use context.toMetadata in all grpc-connection based unary RPC calls, rather than toJSON, which doesn't do an automatic token refresh even when it is provided.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I will add a test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
